### PR TITLE
fix: add Page.loadEventFired listener before navigating

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -196,9 +196,11 @@ describe('HtmlPdf', () => {
             <body>
               <div id="test">Failed!</div>
               <script>
-                setTimeout(() => {
-                  document.getElementById('test').innerHTML = 'Passed!';
-                }, 100);
+                document.addEventListener('DOMContentLoaded', () => {
+                  setTimeout(() => {
+                    document.getElementById('test').innerHTML = 'Passed!';
+                  }, 500);
+                });
               </script>
             </body>
           </html>
@@ -214,7 +216,7 @@ describe('HtmlPdf', () => {
         it('should generate correctly after being triggered', async () => {
           const options: HtmlPdf.CreateOptions = {
             port,
-            completionTrigger: new HtmlPdf.CompletionTrigger.Timer(200),
+            completionTrigger: new HtmlPdf.CompletionTrigger.Timer(600),
           };
           const result = await HtmlPdf.create(html, options);
           expect(result).to.be.an.instanceOf(HtmlPdf.CreateResult);

--- a/test/index.ts
+++ b/test/index.ts
@@ -196,11 +196,9 @@ describe('HtmlPdf', () => {
             <body>
               <div id="test">Failed!</div>
               <script>
-                document.addEventListener('DOMContentLoaded', () => {
-                  setTimeout(() => {
-                    document.getElementById('test').innerHTML = 'Passed!';
-                  }, 500);
-                });
+                setTimeout(() => {
+                  document.getElementById('test').innerHTML = 'Passed!';
+                }, 200);
               </script>
             </body>
           </html>
@@ -216,7 +214,7 @@ describe('HtmlPdf', () => {
         it('should generate correctly after being triggered', async () => {
           const options: HtmlPdf.CreateOptions = {
             port,
-            completionTrigger: new HtmlPdf.CompletionTrigger.Timer(600),
+            completionTrigger: new HtmlPdf.CompletionTrigger.Timer(300),
           };
           const result = await HtmlPdf.create(html, options);
           expect(result).to.be.an.instanceOf(HtmlPdf.CreateResult);


### PR DESCRIPTION
When navigating it sometimes happens that the navigate callback result is sent after the `Page.loadEventFired` event is sent. The result is that the PDF generation promise never resolves. With this PR the `generate` function first sets the `Page.loadEventFired` listener and calls `navigate` after.

For my personally at least 50% of the tests were failing locally every time. Which tests failed seemed pretty random. Now they consistently pass. Just out of curiosity, have you never encountered this issue?