### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ after_success:
 
 language: node_js
 node_js:
-  - node
+  - 11
   - 10
   - 8
   - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ after_success:
 
 language: node_js
 node_js:
+  - node
   - 10
-  - 9
   - 8
   - 6
 


### PR DESCRIPTION
Node.js 9 has already reached its EOL (like most other odd release branches).

We should test on LTS 6, 8, 10 and current stable (11).