### PR TITLE
ci: use the Chrome addon for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,9 @@ git:
   depth: 1
 
 addons:
-  apt:
-    packages:
-      - google-chrome-stable
+  chrome: stable
 before_install:
 #  - npm install -g greenkeeper-lockfile@1
-  - |
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      brew tap caskroom/versions > /dev/null
-      brew cask install google-chrome
-    fi
 
 before_script:
 #  - greenkeeper-lockfile-update


### PR DESCRIPTION
We can use the new Chrome plugin for all platforms.