### PR TITLE
Feature/better network logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-typescript": "^5.0.0",
     "mocha": "^7.0.1",
     "mock-fs": "^4.5.0",
+    "mockttp": "^0.19.2",
     "pdf2json": "^1.1.7",
     "remap-istanbul": "^0.13.0",
     "sinon": "^8.0.0",

--- a/src/CreateOptions.ts
+++ b/src/CreateOptions.ts
@@ -115,6 +115,9 @@ export interface CreateOptions {
    */
   runtimeExceptionHandler?: (exception: ExceptionThrown) => void;
 
+  loadingFailedHandler?: (requestId: number, errorText: string) => void;
+
+  
   /**
    * A private flag to signify the operation has been canceled.
    *

--- a/src/CreateOptions.ts
+++ b/src/CreateOptions.ts
@@ -111,12 +111,12 @@ export interface CreateOptions {
   failOnHTTP4xx?: boolean;
 
    /**
-   * Set to true if a 5xx status code on the main request should lead to a failure.
-   * Not setting this will assume "true"
-   *
-   * @type {boolean}
-   * @memberof CreateOptions
-   */
+    * Set to true if a 5xx status code on the main request should lead to a failure.
+    * Not setting this will assume "true"
+    *
+    * @type {boolean}
+    * @memberof CreateOptions
+    */
   failOnHTTP5xx?: boolean;
 
   /**
@@ -146,9 +146,6 @@ export interface CreateOptions {
    * @memberof CreateOptions
    */
   requestWillBeSentHandler?: (e: any) => void;
-
-
-
 
   /**
    * A private flag to signify the operation has been canceled.

--- a/src/CreateOptions.ts
+++ b/src/CreateOptions.ts
@@ -1,6 +1,8 @@
 'use strict';
 
 import { CompletionTrigger } from './CompletionTriggers';
+import LoadingFailed from './typings/chrome/Network/LoadingFailed';
+import RequestWillBeSent from './typings/chrome/Network/RequestWillBeSent';
 import SetCookieOptions from './typings/chrome/Network/SetCookieOptions';
 import PrintToPDFOptions from './typings/chrome/Page/PrintToPDFOptions';
 import ConsoleAPICalled from './typings/chrome/Runtime/ConsoleAPICalled';
@@ -138,14 +140,14 @@ export interface CreateOptions {
    *
    * @memberof CreateOptions
    */
-  loadingFailedHandler?: (requestId: number, errorText: string) => void;
+  loadingFailedHandler?: (e: LoadingFailed) => void;
 
   /**
    * Set a callback to receive information about requests which will be sent
    *
    * @memberof CreateOptions
    */
-  requestWillBeSentHandler?: (e: any) => void;
+  requestWillBeSentHandler?: (e: RequestWillBeSent) => void;
 
   /**
    * A private flag to signify the operation has been canceled.

--- a/src/CreateOptions.ts
+++ b/src/CreateOptions.ts
@@ -102,6 +102,24 @@ export interface CreateOptions {
   extraHTTPHeaders?: { [key: string]: string; };
 
   /**
+   * Set to true if a 4xx status code on the main request should lead to a failure
+   * Not setting this will assume "true"
+   *
+   * @type {boolean}
+   * @memberof CreateOptions
+   */
+  failOnHTTP4xx?: boolean;
+
+   /**
+   * Set to true if a 5xx status code on the main request should lead to a failure.
+   * Not setting this will assume "true"
+   *
+   * @type {boolean}
+   * @memberof CreateOptions
+   */
+  failOnHTTP5xx?: boolean;
+
+  /**
    * Set a callback to receive console messages.
    *
    * @memberof CreateOptions
@@ -115,9 +133,23 @@ export interface CreateOptions {
    */
   runtimeExceptionHandler?: (exception: ExceptionThrown) => void;
 
+  /**
+   * Set a callback to receive information about failed requests
+   *
+   * @memberof CreateOptions
+   */
   loadingFailedHandler?: (requestId: number, errorText: string) => void;
 
-  
+  /**
+   * Set a callback to receive information about requests which will be sent
+   *
+   * @memberof CreateOptions
+   */
+  requestWillBeSentHandler?: (e: any) => void;
+
+
+
+
   /**
    * A private flag to signify the operation has been canceled.
    *
@@ -141,4 +173,12 @@ export interface CreateOptions {
    * @memberof CreateOptions
    */
   _navigateFailed?: boolean;
+
+  /**
+   * A private flag to hold the status code returned from the main request
+   *
+   * @type {number}
+   * @memberof CreateOptions
+   */
+  _responseStatusCode?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
     if (options.requestWillBeSentHandler) {
       options.requestWillBeSentHandler(e);
     }
-    
+
   });
   Network.loadingFailed((e) => {
     if (e.requestId === options._mainRequestId) {
@@ -133,7 +133,7 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
     if (e.requestId === options._mainRequestId) {
       options._responseStatusCode = e.response.status;
       if (true === options.dumpMainResponseObjectToConsole) {
-        console.log("RESPONSE TO MAIN REQUEST", e.response);
+        console.log('RESPONSE TO MAIN REQUEST', e.response);
       }
     }
   });
@@ -180,11 +180,11 @@ async function throwIfCanceledOrFailed(options: CreateOptions): Promise<void> {
   if (options._navigateFailed) {
     throw new Error('HtmlPdf.create() page navigate failed.');
   }
-  if (options._responseStatusCode != null && false != options.failOnHTTP4xx && options._responseStatusCode >= 400 && options._responseStatusCode <= 499) {
-    throw new Error('HtmlPdf.create() status code '+options._responseStatusCode);
+  if (options._responseStatusCode !== null && false !== options.failOnHTTP4xx && options._responseStatusCode >= 400 && options._responseStatusCode <= 499) {
+    throw new Error('HtmlPdf.create() status code ' + options._responseStatusCode);
   }
-  if (options._responseStatusCode != null && false != options.failOnHTTP5xx && options._responseStatusCode >= 500 && options._responseStatusCode <= 599) {
-    throw new Error('HtmlPdf.create() status code '+options._responseStatusCode);
+  if (options._responseStatusCode != null && false !== options.failOnHTTP5xx && options._responseStatusCode >= 500 && options._responseStatusCode <= 599) {
+    throw new Error('HtmlPdf.create() status code ' + options._responseStatusCode);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,10 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
   }
   Network.requestWillBeSent((e) => {
     options._mainRequestId = options._mainRequestId || e.requestId;
+    if (options.requestWillBeSentHandler) {
+      options.requestWillBeSentHandler(e);
+    }
+    
   });
   Network.loadingFailed((e) => {
     if (e.requestId === options._mainRequestId) {
@@ -123,6 +127,14 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
     }
     if (options.loadingFailedHandler) {
       options.loadingFailedHandler(e.requestId, e.errorText);
+    }
+  });
+  Network.responseReceived((e) => {
+    if (e.requestId === options._mainRequestId) {
+      options._responseStatusCode = e.response.status;
+      if (true === options.dumpMainResponseObjectToConsole) {
+        console.log("RESPONSE TO MAIN REQUEST", e.response);
+      }
     }
   });
   if (options.extraHTTPHeaders) {
@@ -167,6 +179,12 @@ async function throwIfCanceledOrFailed(options: CreateOptions): Promise<void> {
   }
   if (options._navigateFailed) {
     throw new Error('HtmlPdf.create() page navigate failed.');
+  }
+  if (options._responseStatusCode != null && false != options.failOnHTTP4xx && options._responseStatusCode >= 400 && options._responseStatusCode <= 499) {
+    throw new Error('HtmlPdf.create() status code '+options._responseStatusCode);
+  }
+  if (options._responseStatusCode != null && false != options.failOnHTTP5xx && options._responseStatusCode >= 500 && options._responseStatusCode <= 599) {
+    throw new Error('HtmlPdf.create() status code '+options._responseStatusCode);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
       options._navigateFailed = true;
     }
     if (options.loadingFailedHandler) {
-      options.loadingFailedHandler(e.requestId, e.errorText);
+      options.loadingFailedHandler(e);
     }
   });
   Network.responseReceived((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,9 +132,6 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
   Network.responseReceived((e) => {
     if (e.requestId === options._mainRequestId) {
       options._responseStatusCode = e.response.status;
-      if (true === options.dumpMainResponseObjectToConsole) {
-        console.log('RESPONSE TO MAIN REQUEST', e.response);
-      }
     }
   });
   if (options.extraHTTPHeaders) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,9 @@ async function beforeNavigate(options: CreateOptions, client: any): Promise<void
     if (e.requestId === options._mainRequestId) {
       options._navigateFailed = true;
     }
+    if (options.loadingFailedHandler) {
+      options.loadingFailedHandler(e.requestId, e.errorText);
+    }
   });
   if (options.extraHTTPHeaders) {
     Network.setExtraHTTPHeaders({headers: options.extraHTTPHeaders});

--- a/src/typings/chrome/Network/BlockedReason.ts
+++ b/src/typings/chrome/Network/BlockedReason.ts
@@ -1,0 +1,1 @@
+export type BlockedReason = 'other' | 'csp' | 'mixed-content' | 'origin' | 'inspector' | 'subresource-filter' | 'content-type' | 'collapsed-by-client';

--- a/src/typings/chrome/Network/LoadingFailed.ts
+++ b/src/typings/chrome/Network/LoadingFailed.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+import { Timestamp } from '../Runtime/Timestamp';
+import { BlockedReason } from './BlockedReason';
+import { ResourceType } from './ResourceType';
+
+/**
+ * Chrome Network.LoadingFailed event
+ *
+ * @export
+ * @interface LoadingFailed
+ */
+export default interface LoadingFailed {
+  /**
+   * Network Request ID
+   *
+   * @type {string}
+   * @memberof LoadingFailed
+   */
+  requestId: string;
+
+  /**
+   * Timestamp of the request
+   *
+   * @type {Timestamp}
+   * @memberof LoadingFailed
+   */
+  timestamp: Timestamp;
+
+  /**
+   * Type of resource requested
+   *
+   * @type {ResourceType}
+   * @memberof LoadingFailed
+   */
+  type: ResourceType;
+
+  /**
+   * True if loading was canceled.
+   *
+   * @type {boolean}
+   * @memberof LoadingFailed
+   */
+  canceled?: boolean;
+
+  /**
+   * The reason why loading was blocked, if any.
+   *
+   * @type {BlockedReason}
+   * @memberof LoadingFailed
+   */
+  blockedReason?: BlockedReason;
+
+}

--- a/src/typings/chrome/Network/RequestWillBeSent.ts
+++ b/src/typings/chrome/Network/RequestWillBeSent.ts
@@ -1,0 +1,93 @@
+'use strict';
+
+import { Timestamp } from '../Runtime/Timestamp';
+import { ResourceType } from './ResourceType';
+import { TimeSinceEpoch } from './TimeSinceEpoch';
+
+/**
+ * Chrome Network.requestWillBeSent event
+ *
+ * @export
+ * @interface RequestWillBeSent
+ */
+export default interface RequestWillBeSent {
+  /**
+   * Network Request ID
+   *
+   * @type {string}
+   * @memberof RequestWillBeSent
+   */
+  requestId: string;
+
+  /**
+   * Network Loader ID
+   *
+   * @type {string}
+   * @memberof RequestWillBeSent
+   */
+  loaderId: string;
+
+  /**
+   * Request Data as per https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Request
+   *
+   * @type {any}
+   * @memberof RequestWillBeSent
+   */
+  request: any;
+
+  /**
+   * Timestamp of the request
+   *
+   * @type {Timestamp}
+   * @memberof RequestWillBeSent
+   */
+  timestamp: Timestamp;
+
+  /**
+   * Timestamp of the request in TimeSinceEpoch format
+   *
+   * @type {TimeSinceEpoch}
+   * @memberof RequestWillBeSent
+   */
+  wallTime: TimeSinceEpoch;
+
+  /**
+   * Initiator of the request as per https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Initiator
+   *
+   * @type {any}
+   * @memberof RequestWillBeSent
+   */
+  initiator: any;
+
+  /**
+   * Redirect Response data as per https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Response
+   *
+   * @type {any}
+   * @memberof RequestWillBeSent
+   */
+  redirectResponse?: any;
+
+  /**
+   * Type of resource requested
+   *
+   * @type {ResourceType}
+   * @memberof RequestWillBeSent
+   */
+  resourceType?: ResourceType;
+
+  /**
+   * Frame ID
+   *
+   * @type {string}
+   * @memberof RequestWillBeSent
+   */
+  frameId?: string;
+
+  /**
+   * Whether the request is initiated by a user gesture.
+   *
+   * @type {boolean}
+   * @memberof RequestWillBeSent
+   */
+  hasUserGesture?: boolean;
+}

--- a/src/typings/chrome/Network/ResourceType.ts
+++ b/src/typings/chrome/Network/ResourceType.ts
@@ -1,0 +1,1 @@
+export type ResourceType = 'Document' | 'Stylesheet' | 'Image' | 'Media' | 'Font' | 'Script' | 'TextTrack' | 'XHR' | 'Fetch' | 'EventSource' | 'WebSocket' | 'Manifest' | 'SignedExchange' | 'Ping' | 'CSPViolationReport' | 'Other';

--- a/test/index.ts
+++ b/test/index.ts
@@ -334,7 +334,10 @@ describe('HtmlPdf', () => {
         const myOptions = Object.assign({}, baseOptions);
         let alreadyReceivedLoadingFailedHandler = false;
 
-        myOptions.loadingFailedHandler = () => {
+        myOptions.loadingFailedHandler = (e) => {
+          expect(e.requestId).to.not.be.null;
+          expect(e.timestamp).to.not.be.null;
+          expect(e.type).to.not.be.null;
           alreadyReceivedLoadingFailedHandler = true;
           done();
         };
@@ -426,7 +429,13 @@ describe('HtmlPdf', () => {
       it('should trigger requestWillBeSentHandler', (done) => {
         const myOptions = Object.assign({}, baseOptions);
         let alreadyReceivedRequestWillBeSentHandler = false;
-        myOptions.requestWillBeSentHandler = () => {
+        myOptions.requestWillBeSentHandler = (e) => {
+          expect(e.initiator).to.not.null;
+          expect(e.requestId).to.not.null;
+          expect(e.loaderId).to.not.null;
+          expect(e.timestamp).to.not.null;
+          expect(e.wallTime).to.not.null;
+          expect(e.request).to.not.null;
           done();
           alreadyReceivedRequestWillBeSentHandler = true;
         };


### PR DESCRIPTION
This introduces a few features for better handling of errors and better debuggability.

CreateOptions introduces new properties:
```
  /**
   * Set to true if a 4xx status code on the main request should lead to a failure
   * Not setting this will assume "true"
   *
   * @type {boolean}
   * @memberof CreateOptions
   */
  failOnHTTP4xx?: boolean;

   /**
    * Set to true if a 5xx status code on the main request should lead to a failure.
    * Not setting this will assume "true"
    *
    * @type {boolean}
    * @memberof CreateOptions
    */
  failOnHTTP5xx?: boolean;

```
This is to prevent PDFs to be created for pages which actually failed.

For better analysis/debugging of pages which don't render properly, I have also two handlers for network requests:
```
 /**
   * Set a callback to receive information about failed requests
   *
   * @memberof CreateOptions
   */
  loadingFailedHandler?: (e: LoadingFailed) => void;

  /**
   * Set a callback to receive information about requests which will be sent
   *
   * @memberof CreateOptions
   */
  requestWillBeSentHandler?: (e: RequestWillBeSent) => void;
```
Essentially this will give you some insight on what kind of requests are going out and which are actually failing.

I have added typings for the LoadingFailed/RequestWillBeSent but only to a degree. The request/response fields contained in these interfaces are just set to `any` as I didn't have the time to create the whole type tree behind
https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Response
and
https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Request

Any questions/issues please let me know.
And please bear with me on the TypeScript event, this is the first time I use typescript so far (started using it a few days ago only).

