### PR TITLE
Expose the main HTTP request response.

### DIFF
--- a/src/CreateOptions.ts
+++ b/src/CreateOptions.ts
@@ -121,10 +121,18 @@ export interface CreateOptions {
   _mainRequestId?: string;
 
   /**
+   * A private variable to store the main page navigation response.
+   *
+   * @type {Protocol.Network.Response}
+   * @memberof CreateOptions
+   */
+  _mainRequestResponse?: Protocol.Network.Response;
+
+  /**
    * A private flag to signify that generation failed or timed out.
    *
    * @type {Error}
    * @memberof CreateOptions
    */
-    _exitCondition?: Error;
+  _exitCondition?: Error;
 }

--- a/src/CreateResult.ts
+++ b/src/CreateResult.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import Protocol from 'devtools-protocol';
 import * as fs from 'fs';
 import { Readable, Stream } from 'stream';
 
@@ -40,13 +41,20 @@ export class CreateResult {
   private data: string;
 
   /**
+   * The main page network response, if any.
+   */
+   readonly response?: Protocol.Network.Response;
+
+  /**
    * Creates an instance of CreateResult.
    * @param {string} data base64 PDF data
+   * @param {Protocol.Network.Response} response the main page network response, if any.
    *
    * @memberof CreateResult
    */
-  public constructor(data: string) {
+  public constructor(data: string, response?: Protocol.Network.Response) {
     this.data = data;
+    this.response = response;
   }
 
   /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -80,7 +80,7 @@ describe('HtmlPdf', () => {
       };
 
       try {
-        await HtmlPdf.create('https://westy92.github.io/html-pdf-chrome/test/cookie.html', options);
+        await HtmlPdf.create('<p>hello!</p>', options);
         expect.fail();
       } catch (err) {
         expect(err.message).to.equal('HtmlPdf.create() connection lost.');
@@ -143,6 +143,19 @@ describe('HtmlPdf', () => {
       };
       const result = await HtmlPdf.create('<p>hello!</p>', options);
       expect(result).to.be.an.instanceOf(HtmlPdf.CreateResult);
+    });
+
+    it('should generate without a response object if not using a path', async () => {
+      const result = await HtmlPdf.create('<p>hello!</p>', { port });
+      expect(result).to.be.an.instanceOf(HtmlPdf.CreateResult);
+      expect(result.response).to.be.undefined;
+    });
+
+    it('should generate with a response object if using a path', async () => {
+      const url = 'https://www.google.com/';
+      const result = await HtmlPdf.create(url, { port });
+      expect(result.response.url).to.equal(url);
+      expect(result.response.status).to.equal(200);
     });
 
     it('should generate a PDF with cookies', async () => {
@@ -253,7 +266,7 @@ describe('HtmlPdf', () => {
       const html = `
         <html>
           <head>
-            <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+            <script src="https://code.jquery.com/jquery-3.6.0.slim.min.js"></script>
           </head>
           <body>
             <div id="test">Failed!</div>


### PR DESCRIPTION
This allows you to inspect the main HTTP response to decide if you want to save the generated PDF or not. For example, you may wish to retry if the response is 4xx or 5xx, even though some content is received from the server.

Note that the response is optional and won't be added if you are supplying HTML directly. See added test cases for examples.